### PR TITLE
remove note about custom fork of tools.namespace for test-runner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1570,9 +1570,6 @@
                       <a href="https://github.com/cognitect-labs/test-runner">test-runner</a>
                       
                       
-                      <i class="pointer" title="Needs babashka fork of tools.namespace.
-">ℹ️</i>
-                      
                     </li>
                     
                   </ul>

--- a/projects.yml
+++ b/projects.yml
@@ -7,8 +7,6 @@ test_runner:
   name: test-runner
   url: https://github.com/cognitect-labs/test-runner
   categories: [Test Runners]
-  notes: |
-    Needs babashka fork of tools.namespace.
 
 spec_alpha:
   name: spec.alpha
@@ -394,20 +392,10 @@ hashp:
   url: https://github.com/weavejester/hashp
   categories: [Debugging]
 
-hashp:
-  name: hashp
-  url: https://github.com/weavejester/hashp
-  categories: [Debugging]
-
 faker:
   name: Faker
   url: https://github.com/paraseba/faker
   categories: [Random Data Generation]
-
-clansi:
-  name: Clansi
-  url: https://github.com/ams-clj/clansi
-  categories: [Terminal Utilities]
 
 clansi:
   name: Clansi


### PR DESCRIPTION
Pursuant to the slack convo: 
<https://clojurians.slack.com/archives/CLX41ASCS/p1728166794560259?thread_ts=1728166739.790129&cid=CLX41ASCS>

The main purpose of this PR is to remove the note on test-runner that says it needs the bb fork of `tools.namespace`. While making this change, IntelliJ pointed out some duplicated entries in projects.yml (specifically, `hashp` and `clansi`), so I removed them as a housekeeping measure.

